### PR TITLE
Add support for authenticating with ACL

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -767,6 +767,10 @@ module MakeClient(Mode: Mode) = struct
     let command = [ "AUTH"; password ] in
     send_request connection command >>= return_ok_status
 
+  let auth_acl connection username password =
+    let command = [ "AUTH"; username; password ] in
+    send_request connection command >>= return_ok_status
+
   let echo connection message =
     let command = [ "ECHO"; message ] in
     send_request connection command >>= return_bulk

--- a/src/s.ml
+++ b/src/s.ml
@@ -120,6 +120,9 @@ module type Client = sig
   (** Authenticate to server. *)
   val auth : connection -> string -> unit IO.t
 
+  (** Authenticate to server with username and password. *)
+  val auth_acl : connection -> string -> string -> unit IO.t
+
   (** Echo given string. *)
   val echo : connection -> string -> string option IO.t
 


### PR DESCRIPTION
ACL was introduced in Redis 6 and allows authenticating with a username
and password, as well as just a password: https://redis.io/topics/acl